### PR TITLE
Update to Clojurescript 0.0-2202.

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -6,9 +6,9 @@
             :distribution :repo}
 
   :dependencies [[org.clojure/clojure "1.5.1"]
-                 [org.clojure/clojurescript "0.0-2173" :scope "provided"]
-                 [org.clojure/google-closure-library "0.0-20130212-95c19e7f0f5f" :scope "provided"]
-                 [http-kit "2.1.16"]]
+                 [org.clojure/clojurescript "0.0-2202" :scope "provided"]
+                 [org.clojure/google-closure-library "0.0-20140226-71326067" :scope "provided"]
+                 [http-kit "2.1.18"]]
 
-  :profiles {:dev {:dependencies [[com.cemerick/piggieback "0.1.2"]]}}
+  :profiles {:dev {:dependencies [[com.cemerick/piggieback "0.1.3"]]}}
   :source-paths ["src/clj" "src/cljs"])

--- a/src/clj/weasel/repl/websocket.clj
+++ b/src/clj/weasel/repl/websocket.clj
@@ -3,6 +3,7 @@
   (:require [cljs.repl]
             [cljs.closure :as cljsc]
             [cljs.compiler :as cmp]
+            [cljs.js-deps :as js-deps]
             [cljs.env :as env]
             [clojure.set :as set]
             [weasel.repl.server :as server]))
@@ -47,7 +48,7 @@
                 :preloaded-libs []
                 :src "src/"}
                opts)]
-    (swap! compiler-env assoc :js-dependency-index (cljsc/js-dependency-index opts))
+    (swap! compiler-env assoc :js-dependency-index (js-deps/js-dependency-index opts))
     (env/with-compiler-env (::env/compiler opts)
       (reset! preloaded-libs
         (set/union


### PR DESCRIPTION
Hi Tom,

in Clojurescript 0.0-2202 the `js-dependency-index` fn moved from
`cljs.compiler` to `cljs.js-deps`. This pull requests updates the
dependencies and fixes the import of `js-dependency-index`.

Would you like to merge this and publish a new release? 

Thanks, Roman.
