### PR TITLE
Remove extra parens when no stacktrace available.

### DIFF
--- a/src/cljs/weasel/repl.cljs
+++ b/src/cljs/weasel/repl.cljs
@@ -30,7 +30,7 @@
                  :value (pr-str e)
                  :stacktrace (if (.hasOwnProperty e "stack")
                                (.-stack e)
-                               ("No stacktrace available."))}))}))
+                               "No stacktrace available.")}))}))
 
 (defn repl-print
   [x]


### PR DESCRIPTION
`weasel.repl/process-message` for `:eval-js` currently tries to _call_ the string "No stacktrace available" when processing an error with no stacktrace. This results in a new error and the repl hanging. Instead it should just return the string as a value, which would match the behavior of `clojure.browser.repl/evaluate-javascript`.
