### PR TITLE
Rename EventType protocol and update dependencies

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -5,8 +5,8 @@
             :url "http://unlicense.org/UNLICENSE"
             :distribution :repo}
 
-  :dependencies [[org.clojure/clojure "1.5.1"]
-                 [org.clojure/clojurescript "0.0-2202" :scope "provided"]
+  :dependencies [[org.clojure/clojure "1.6.0"]
+                 [org.clojure/clojurescript "0.0-2311" :scope "provided"]
                  [org.clojure/google-closure-library "0.0-20140226-71326067" :scope "provided"]
                  [http-kit "2.1.18"]]
 

--- a/src/cljs/weasel/impls/websocket.cljs
+++ b/src/cljs/weasel/impls/websocket.cljs
@@ -40,7 +40,7 @@
   (close [this]
     (.close this ()))
 
-  event/EventType
+  event/IEventType
   (event-types [this]
     (into {}
       (map

--- a/weasel-example/project.clj
+++ b/weasel-example/project.clj
@@ -5,8 +5,8 @@
             :url "http://unlicense.org/UNLICENSE"
             :distribution :repo}
 
-  :dependencies [[org.clojure/clojure "1.5.1"]
-                 [org.clojure/clojurescript "0.0-2202"]
+  :dependencies [[org.clojure/clojure "1.6.0"]
+                 [org.clojure/clojurescript "0.0-2311"]
                  [weasel "0.3.0"]]
 
   :source-paths ["src"]


### PR DESCRIPTION
I'm new to Clojure and not sure if updating the dependencies of your project is what you want to do in this situation. Anway, ClojureScript 0.0-2311 changed the event/EventType protocol to event/IEventType. Furthermore, with the new version of ClojureScript, the weasel-example project won't compile unless I upgrade to Clojure 1.6.0 (which makes sense considering this message from David Nolen: https://groups.google.com/d/msg/clojurescript/MEFJ5D7g8yM/cbiJJTyrKjsJ).
