### PR TITLE
Fixing Uncaught TypeError: Cannot read property 'autoReconnect' of null (and add deps.edn)

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -1,0 +1,4 @@
+{:deps  {org.clojure/clojurescript {:mvn/version "1.10.520"}
+         org.clojure/clojure       {:mvn/version "1.10.0"}
+         http-kit                  {:mvn/version "2.3.0"}}
+ :paths ["src/clj" "src/cljs"]}

--- a/src/cljs/weasel/impls/websocket.cljs
+++ b/src/cljs/weasel/impls/websocket.cljs
@@ -20,7 +20,7 @@
   ([auto-reconnect?]
      (websocket-connection auto-reconnect? nil))
   ([auto-reconnect? next-reconnect-fn]
-     (goog.net.WebSocket. auto-reconnect? next-reconnect-fn)))
+     (goog.net.WebSocket. (or auto-reconnect? false) (or next-reconnect-fn false))))
 
 (extend-type goog.net.WebSocket
   IWebSocket


### PR DESCRIPTION
When we are trying to instantiate and goog.net.WebSocket object, it breaks with nil/null option.
So I pass `false` when params are nil.

I also added `deps.edn` to make it simpler to use `:git` with a specific sha in deps.edn